### PR TITLE
Add module import to readme

### DIFF
--- a/projects/mat-icon-button-sizes/README.md
+++ b/projects/mat-icon-button-sizes/README.md
@@ -29,13 +29,11 @@ npm i -S mat-icon-button-sizes
 import { MatIconButtonSizesModule } from 'mat-icon-button-sizes';
 
 @NgModule({
-   declarations: [AppComponent],
    imports: [
       ...
       MatIconButtonSizesModule,
    ],
-   providers: [],
-   bootstrap: [AppComponent],
+   ...
 })
 export class AppModule {}
 ```

--- a/projects/mat-icon-button-sizes/README.md
+++ b/projects/mat-icon-button-sizes/README.md
@@ -23,6 +23,22 @@ npm i -S mat-icon-button-sizes
 // @import your Angular Material theme before!
 @import "../node_modules/mat-icon-button-sizes/styles/mat-icon-button-sizes";
 ```
+```ts
+// app.module.ts
+// Import the module into your app module.
+import { MatIconButtonSizesModule } from 'mat-icon-button-sizes';
+
+@NgModule({
+   declarations: [AppComponent],
+   imports: [
+      ...
+      MatIconButtonSizesModule,
+   ],
+   providers: [],
+   bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
 ```html
 <button mat-icon-button mat-large-icon-button>
    <mat-icon>delete</mat-icon>


### PR DESCRIPTION
I found and decided to use this library and noticed that the readme didn't have instructions to add your module into the app.module. I know it should very much be self-explanatory to an Angular developer but I just thought you might want it there.